### PR TITLE
refactor: toolchain register API

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,9 @@ build:macos_toolchains --build_tag_filters=
 build:linux --config=macos_toolchains
 build:windows --config=macos_toolchains
 build:macos --build_tag_filters=-darwin_c
+# build:macos --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build --toolchain_resolution_debug='@bazel_tools//tools/cpp:toolchain_type'
 
 test --sandbox_default_allow_network=false
 test --test_output=errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        os: [macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -13,5 +13,9 @@ build:linux --sandbox_add_mount_pair=/tmp
 build:macos --sandbox_add_mount_pair=/var/tmp
 build:windows --sandbox_add_mount_pair=C:\Temp
 
+# build:macos --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build --toolchain_resolution_debug='@bazel_tools//tools/cpp:toolchain_type'
+
 test --sandbox_default_allow_network=false
 test --test_output=errors


### PR DESCRIPTION
BREAKING CHANGE: `@zig_toolchains` repository to hold all toolchain definitions.

Simplify toolchain registering API.

#### MODULE.bazel:
toolchain module_extension now creates repositories:

- `@zig_skd`: holds all common platforms & constraints definitions
- `@zig_config-{os}-{arch}`: contains toolchain config rules and all needed targets to register toolchains for particular platform
- `@zig_toolchains`: holds all supported toolchain definitions.

#### WORKSPACE:
Comparing to above, the difference here is that only one `@zig_config` repository will be created for the host platform. `@zig_sdk` & `@zig_toolchains` are the same as for `bzlmod` case.

Possible toolchain registration with:

```starlark
register_toolchains(
    "@zig_toolchains//...",
)
```